### PR TITLE
2.2.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.0-rc.1
+* Avoiding excessive memory usage when reading content from `content scheme` by only reading new data chunk when the previous one has been consumed.
+
 ## 2.1.1
 * Fixing docs
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-`uri_content` enables you to fetch the content of a URI without generating any temporary files during the process. 
-You need not worry about any residual garbage being left behind.
+`uri_content` enables you to fetch the content of a URI without generating any temporary files during the process.
 
 It supports the following schemes: `file`, `data`, `http/https`, `content` (Android only)
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -270,7 +270,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.1.1"
+    version: "2.2.0-rc.1"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: uri_content
 description: Get the Uint8List content of a given Uri. Supports file, data, content and http/https
-version: 2.1.1
+version: 2.2.0-rc.1
 homepage: https://github.com/talesbarreto/uri_content
 topics:
   - uri


### PR DESCRIPTION
* Avoiding excessive memory usage when reading content from `content scheme` by only reading new data chunk when the previous one has been consumed.