### PR TITLE
2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
-## 2.2.0-rc.2
-* Fixing an issue that caused concurrent calls from multiple isolates to fail on the `content` schema.
-* Increasing data reading chunk size from 512KB to 10MB
-
-## 2.2.0-rc.1
+## 2.2.0
 * Avoiding excessive memory usage when reading content from `content scheme` by only reading new data chunk when the previous one has been consumed.
+* Min SDK version is now 2.17.0
 
 ## 2.1.1
 * Fixing docs

--- a/README.md
+++ b/README.md
@@ -6,11 +6,20 @@ It supports the following schemes: `file`, `data`, `http/https`, `content` (Andr
 
 ```dart
 import 'package:uri_content/uri_content.dart';
+```
+
+There are two ways to use this package: `extension methods` that allow you to fetch content directly from a URI like it was a native method, or through a `UriContent` instance.
+
+
+### UriContent
+
+`UriContent` is preferred because it offers additional options such as custom HTTP headers and the ability to adjust the default buffer size for content schemes. It also facilitates code testing since you can mock its instance.
+
+```dart
+import 'package:uri_content/uri_content.dart';
 
 final uriContent = UriContent();
 ```
-
-`UriContent` is preferred because it offers additional options such as custom HTTP headers and the ability to adjust the default buffer size for content schemes. It also facilitates code testing since you can mock its instance.
 
 
 ```dart
@@ -26,7 +35,7 @@ Future<void> getReadmeLength() async {
 }
 ```
 
-### getContentStream()
+#### getContentStream()
 
 This method retrieves a Stream of Uint8List where each event represents a chunk of content from the specified URI. This approach is more suitable when you don't need the entire content at once, such as in a request provider or when directly saving the bytes into a File. Handling small chunks significantly reduces memory consumption.
 
@@ -34,7 +43,7 @@ This method retrieves a Stream of Uint8List where each event represents a chunk 
 Stream<Uint8List> contentStream = uriContent.getContentStream(uri);
 ```
 
-### from()
+#### from()
 
 This method retrieves the entire content at once. Be cautious as it may crash your app when attempting to retrieve a large file.
 - Throws exception if it was nos possible to get the content
@@ -43,7 +52,7 @@ This method retrieves the entire content at once. Be cautious as it may crash yo
 Future<Uint8List> content = uriContent.from(uri);
 ```
 
-### fromOrNull()
+#### fromOrNull()
 
 Similar to `from`, but returns null instead of throwing an exception when an error happens.
 
@@ -51,7 +60,7 @@ Similar to `from`, but returns null instead of throwing an exception when an err
 Future<Uint8List?> content = uriContent.fromOrNull(uri);
 ```
 
-### canFetchContent()
+#### canFetchContent()
 
 This method checks if it is possible to fetch the content from the specified Uri. If it is a file, it checks if it exists. If it is a http/https Uri, it checks if it is reachable.
 
@@ -59,19 +68,19 @@ This method checks if it is possible to fetch the content from the specified Uri
 Future<bool> canFetch = uriContent.canFetchContent(uri);
 ```
 
-### getContentLength()
+#### getContentLength()
 returns the content length in bytes of the specified Uri.
- - It relies on metadata to get the content length, so it may **not** be accurate.
- - It may throw an exception if the content is not reachable.
- - If the content length is not available, it returns `null`.
+- It relies on metadata to get the content length so it may **not** be accurate.
+- It may throw an exception if the content is not reachable.
+- If the content length is not available, it returns `null`.
 
 ```dart
 Future<int?> contentLength = uriContent.getContentLength(uri);
 ```
 
-### getContentLengthOrNull()
+#### getContentLengthOrNull()
 
-Similar to `getContentLength`, but return `null` on errors. 
+Similar to `getContentLength`, but return `null` on errors.
 
 Note that `null` is ambiguous; it may indicate that the content is not reachable or the content length is unavailable. Hence, it is recommended to use `getContentLength() and handle its exceptions.
 
@@ -79,7 +88,7 @@ Note that `null` is ambiguous; it may indicate that the content is not reachable
 Future<int?> contentLength = uriContent.getContentLengthOrNull(uri);
 ```
 
-## Using `getContent()` extension
+### Using `getContent()` extension
 
 A handy extension method for `Uri` allows direct fetching of URI content.
 

--- a/example/lib/android_content/data_fetcher.dart
+++ b/example/lib/android_content/data_fetcher.dart
@@ -55,7 +55,10 @@ class DataFetcherInput {
 Future<void> _fetch(DataFetcherInput input) async {
   BackgroundIsolateBinaryMessenger.ensureInitialized(input.token);
   final uriContent = UriContent();
-  final size = await uriContent.getContentLength(input.uri);
-  final data = await uriContent.from(input.uri);
-  input.sendPort.send((size, data));
+
+  final result = await Future.wait([
+    uriContent.getContentLength(input.uri),
+    uriContent.from(input.uri),
+  ]);
+  input.sendPort.send((result.first, result.last));
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -270,7 +270,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.2.0-rc.1"
+    version: "2.2.0"
   vector_math:
     dependency: transitive
     description:

--- a/lib/src/uri_content.dart
+++ b/lib/src/uri_content.dart
@@ -57,7 +57,6 @@ class UriContent {
   /// Get the content from an Uri.
   /// Supported schemes: data, file, http, https, Android content
   ///
-  ///
   /// [httpHeaders] see https://api.flutter.dev/flutter/dart-io/HttpHeaders/add.html
   ///
   /// Throws exception if it was nos possible to get the content
@@ -100,7 +99,8 @@ class UriContent {
   ///
   /// [httpHeaders] see https://api.flutter.dev/flutter/dart-io/HttpHeaders/add.html
   ///
-  /// [bufferSize] sets the total of bytes to be send on each stream event. It ONLY affects `android content` Uris
+  /// [bufferSize] sets the total of bytes to be send on each stream event. It ONLY affects `android content` Uris.
+  /// The default value is 5MB. Lower values reduce the memory consumption. Higher values will considerably increase the performance.
   ///
   /// Warning: To prevent resource leaks, make sure to either listen to the stream until the end or close it
   /// if you want to abort the content reading.

--- a/lib/src/uri_content_schema_handler/android_content_uri_handler.dart
+++ b/lib/src/uri_content_schema_handler/android_content_uri_handler.dart
@@ -42,6 +42,9 @@ class AndroidContentUriHandler implements UriSchemaHandler {
     while (true) {
       final UriContentChunkResult result;
       try {
+        // Ideally, we should continuously send data from Kotlin to Dart and Dart should inform the native code when the stream should be paused.
+        // However, we can not directly send data from Kotlin to Dart directly if we need to work with multiple isolates, like pointed out in this issue https://github.com/talesbarreto/uri_content/issues/10
+        // To overcome this, we request each chunk of data as an ordinary method channel request.
         result = await uriContentApi.requestNextChunk(requestId);
       } catch (e) {
         yield* Stream.error(UriContentError(e.toString()));

--- a/lib/src/uri_content_schema_handler/uri_schema_handler.dart
+++ b/lib/src/uri_content_schema_handler/uri_schema_handler.dart
@@ -20,7 +20,7 @@ abstract class UriSchemaHandler {
 }
 
 class UriSchemaHandlerParams {
-  static const defaultBufferSize = 1024 * 1024 * 10;
+  static const defaultBufferSize = 1024 * 1024 * 5;
 
   final int bufferSize;
   final Map<String, Object> httpHeaders;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: uri_content
 description: Get the Uint8List content of a given Uri. Supports file, data, content and http/https
-version: 2.2.0-rc.2
+version: 2.2.0
 homepage: https://github.com/talesbarreto/uri_content
 topics:
   - uri


### PR DESCRIPTION
* Avoiding excessive memory usage when reading content from `content scheme` by only reading new data chunk when the previous one has been consumed.
* Min SDK version is now 2.17.0