### PR TITLE
Update build.gradle to add conditional for compatibility with AGP <4.2.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,4 +47,9 @@ android {
     dependencies {
         implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1'
     }
+
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.talesbarreto.uri_content'
+    }
 }


### PR DESCRIPTION
Add namespace to work with newer Gradle versions.